### PR TITLE
Discovery precedence of shrek configuration file.

### DIFF
--- a/shrek/scripts/submitWorflowToPanDA.py
+++ b/shrek/scripts/submitWorflowToPanDA.py
@@ -19,21 +19,14 @@ import pprint
 from shrek.scripts.buildJobScript import buildJobScript
 from shrek.scripts.buildCommonWorklow import buildCommonWorkflow
 from shrek.scripts.buildSubmissionDirectory import buildSubmissionDirectory
+from shrek.scripts.ShrekConfiguration import readSiteConfig
 
 def main():
 
     # Default configuration options
-    defaults = {}
-    shrekOpts = {}
-    pandaOpts = {}    
-    with open("shrek/config/site.yaml", "r") as stream:
-        try:
-            defaults = yaml.safe_load(stream)
-            shrekOpts = defaults['Shrek']
-            pandaOpts = defaults['PanDA']
-            print(pandaOpts)
-        except yaml.YAMLError as exc:
-            print(exc)
+    defaults  = readSiteConfig()
+    shrekOpts = defaults['Shrek']
+    pandaOpts = defaults['PanDA']
 
     # Setup the default panda environment to be run in subprocess that launches pchain
     pandaEnv = os.environ.copy()

--- a/shrek/scripts/watchRucioForNewDatasets.py
+++ b/shrek/scripts/watchRucioForNewDatasets.py
@@ -8,19 +8,13 @@ import sh
 import time
 
 from sh import shrek_submit as shrek
+from shrek.scripts.ShrekConfiguration import readSiteConfig
 
 class RucioNonResponsive( Exception ):
     pass
 
-def readConfig( filename ):
-
-    defaults = {}
-    with open(filename,'r') as stream:
-        try:
-            defaults = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
-
+def readConfig( filename ):    
+    defaults = readSiteConfig()    
     return defaults['Donkey']
 
 def readWatchFile( filename ):
@@ -90,7 +84,7 @@ def captureActorError( out ):
        
 def main():
 
-    defaults = readConfig( 'shrek/config/site.yaml' )
+    defaults = readConfig()
 
     parser = argparse.ArgumentParser(description='Monitors rucio for new datasets and submits to PanDA')
 


### PR DESCRIPTION
Setup multiple locations and order of precedence for the shrek configurtion file.

1st priority goes to a "site.yaml" in current working directory.
2nd priority goes to configuration configuration file in the source tree, if it is present.
3rd priority goes to a system install directory if specified by environment variable.